### PR TITLE
#17 coupling to vpce

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -4,6 +4,7 @@ resource "aws_api_gateway_rest_api" "event_gate_api" {
   tags = {"BuiltBy" = "Terraform"}
   endpoint_configuration {
     types = ["PRIVATE"]
+    vpc_endpoint_ids = [var.vpc_endpoint]
   }
   policy = jsonencode({
     Version = "2012-10-17",
@@ -13,6 +14,11 @@ resource "aws_api_gateway_rest_api" "event_gate_api" {
         Action = "execute-api:Invoke",
         Resource = "*",
         Principal = "*"
+		Condition = {
+          StringEquals = {
+            "aws:sourceVpce" = var.vpc_endpoint
+          }
+        }
       }
     ]
   })

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,6 @@
 variable "aws_region" {}
 variable "vpc_id" {}
+variable "vpc_endpoint" {}
 variable "resource_prefix" {}
 variable "lambda_role_arn" {}
 variable "lambda_vpc_subnet_ids" {}


### PR DESCRIPTION
add VPC-Endpoint to API Gateway, so it can be invoked from outside while complying with being accessed from within its own VPC
closes #17 