### PR TITLE
Allow null value for job status/error message in topic_runs.json

### DIFF
--- a/conf/topic_runs.json
+++ b/conf/topic_runs.json
@@ -57,7 +57,7 @@
                         "description": "End timestamp of a job that is a part of a run in epoch milliseconds"
                     },
                     "message": {
-                        "type": "string",
+                        "type": ["string", "null"],
                         "description": "Job status/error message."
                     },
                     "additional_info": {


### PR DESCRIPTION
Fixes #45 

This pull request makes a small change to the `conf/topic_runs.json` schema, allowing the `message` field to accept both string and null values.

Release notes:
- Allow the `message` field to accept both string and null values for the runs topic