### PR TITLE
Update CODEOWNERS to include additional reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ABMC831 @OlivieFranklova @Zejnilovic
+* @ABMC831 @OlivieFranklova @Zejnilovic @oto-macenauer-absa @petr-pokorny-absa


### PR DESCRIPTION
This pull request makes a small update to the `.github/CODEOWNERS` file, adding two additional users as code owners.

Release notes:
- Updated Code owners