### PR TITLE
Fix config file name

### DIFF
--- a/src/event_gate_lambda.py
+++ b/src/event_gate_lambda.py
@@ -54,7 +54,7 @@ with open("conf/topic_test.json", "r") as file:
     TOPICS["public.cps.za.test"] = json.load(file)
 logger.debug("Loaded TOPICS")
 
-with open("conf/config.dev.json", "r") as file:
+with open("conf/config.json", "r") as file:
     CONFIG = json.load(file)
 logger.debug("Loaded main CONFIG")
 


### PR DESCRIPTION
This pull request makes a small but important configuration change to the application. The main configuration file loaded at startup has been switched from `conf/config.dev.json` to `conf/config.json`, which means the application will now use the standard (likely production) configuration by default instead of the development configuration.

- Changed the configuration file loaded in `src/event_gate_lambda.py` from `conf/config.dev.json` to `conf/config.json`.

Release notes:
- Fix config file name