### PR TITLE
Add country field to EDLA schema

### DIFF
--- a/conf/topic_dlchange.json
+++ b/conf/topic_dlchange.json
@@ -25,6 +25,10 @@
             "type": "number",
             "description": "Timestamp of the event in epoch milliseconds"
         },
+        "country": {
+            "type": "string",
+            "description": "The country the data is related to."
+        },
         "catalog_id": {
             "type": "string",
             "description": "Identifier for the data definition (Glue/Hive) database and table name for example "

--- a/conf/topic_runs.json
+++ b/conf/topic_runs.json
@@ -39,6 +39,10 @@
             "items": {
                 "type": "object",
                 "properties": {
+                    "country": {
+                      "type": "string",
+                      "description": "The country the data is related to."
+                    },
                     "catalog_id": {
                         "type": "string",
                         "description": "Identifier for the data definition (Glue/Hive) database and table name for  example"

--- a/src/writers/writer_postgres.py
+++ b/src/writers/writer_postgres.py
@@ -96,6 +96,7 @@ def postgres_edla_write(cursor, table: str, message: Dict[str, Any]) -> None:
             source_app_version,
             environment,
             timestamp_event,
+            country,
             catalog_id,
             operation,
             "location",
@@ -116,6 +117,7 @@ def postgres_edla_write(cursor, table: str, message: Dict[str, Any]) -> None:
             %s,
             %s,
             %s,
+            %s,
             %s
         )""",
         (
@@ -125,6 +127,7 @@ def postgres_edla_write(cursor, table: str, message: Dict[str, Any]) -> None:
             message["source_app_version"],
             message["environment"],
             message["timestamp_event"],
+            message.get("country", ""),
             message["catalog_id"],
             message["operation"],
             message.get("location"),
@@ -187,6 +190,7 @@ def postgres_run_write(cursor, table_runs: str, table_jobs: str, message: Dict[s
         INSERT INTO {table_jobs}
         (
                 event_id,
+                country,
                 catalog_id,
                 status,
                 timestamp_start,
@@ -202,10 +206,12 @@ def postgres_run_write(cursor, table_runs: str, table_jobs: str, message: Dict[s
             %s,
             %s,
             %s,
+            %s,
             %s
         )""",
             (
                 message["event_id"],
+                job.get("country", ""),
                 job["catalog_id"],
                 job["status"],
                 job["timestamp_start"],


### PR DESCRIPTION
## Summary
This pull request adds support for a new `country` field across the data ingestion pipeline. The main goal is to ensure that country information is properly captured, stored, and validated for both event and job records.

## Release Notes:
- Add country field to EDLA schema

Closes #79 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional country field to data change records and job runs to track geographic location of data sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->