### PR TITLE
Dockerfile fixed to include .crt files as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN \
   echo "######################################################" && \
   echo "### Import trusted certs before doing anything else ###" && \
   echo "######################################################" && \
-  for FILE in `ls /opt/certs/*.pem /opt/certs/*.crf`; \
+  for FILE in `ls /opt/certs/*.pem /opt/certs/*.crt`; \
     do cat $FILE >> /etc/pki/tls/certs/ca-bundle.crt ; done && \
   echo "###############################################" && \
   echo "### Install                                  ###" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN \
   echo "######################################################" && \
   for FILE in `ls /opt/certs/*.pem /opt/certs/*.crt`; \
     do cat $FILE >> /etc/pki/tls/certs/ca-bundle.crt ; done && \
-      update-ca-trust && \
   echo "###############################################" && \
   echo "### Install                                  ###" && \
   echo "### -> Basics                                 ###" && \
@@ -47,7 +46,7 @@ RUN \
   echo "#################" && \
     mkdir -p /tmp/env-install-workdir/librdkafka && \
     cd /tmp/env-install-workdir/librdkafka && \
-    wget https://github.com/edenhill/librdkafka/archive/v2.4.0.tar.gz && \
+    wget --ca-certificate=/etc/pki/tls/certs/ca-bundle.crt https://github.com/edenhill/librdkafka/archive/v2.4.0.tar.gz && \
     tar -xf v2.4.0.tar.gz && \
     cd /tmp/env-install-workdir/librdkafka/librdkafka-2.4.0 && \
     ./configure && make && make install && \
@@ -60,7 +59,7 @@ RUN \
   echo "######################" && \
     mkdir -p /tmp/env-install-workdir/confluent-kafka && \
     cd /tmp/env-install-workdir/confluent-kafka && \
-    wget https://github.com/confluentinc/confluent-kafka-python/archive/v2.4.0.tar.gz && \
+    wget --ca-certificate=/etc/pki/tls/certs/ca-bundle.crt https://github.com/confluentinc/confluent-kafka-python/archive/v2.4.0.tar.gz && \
     tar -xf v2.4.0.tar.gz && \
     cd /tmp/env-install-workdir/confluent-kafka/confluent-kafka-python-2.4.0 && \
     CPPFLAGS="-I/usr/local/include" LDFLAGS="-L/opt" python setup.py install && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN \
   echo "######################################################" && \
   echo "### Import trusted certs before doing anything else ###" && \
   echo "######################################################" && \
-  for FILE in `ls /opt/certs/*.pem`; \
+  for FILE in `ls /opt/certs/*.pem /opt/certs/*.crf`; \
     do cat $FILE >> /etc/pki/tls/certs/ca-bundle.crt ; done && \
   echo "###############################################" && \
   echo "### Install                                  ###" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ FROM --platform=linux/arm64 public.ecr.aws/lambda/python:3.13-arm64
 ARG TRUSTED_SSL_CERTS=./trusted_certs
 # Artifacts for kerberized sasl_ssl
 ARG SASL_SSL_ARTIFACTS=./sasl_ssl_artifacts
-RUN apk add --no-cache ca-certificates
 
 # Trusted certs
 COPY $TRUSTED_SSL_CERTS /opt/certs/
@@ -32,7 +31,7 @@ RUN \
   echo "######################################################" && \
   for FILE in `ls /opt/certs/*.pem /opt/certs/*.crt`; \
     do cat $FILE >> /etc/pki/tls/certs/ca-bundle.crt ; done && \
-      update-ca-certificates && \
+      update-ca-trust && \
   echo "###############################################" && \
   echo "### Install                                  ###" && \
   echo "### -> Basics                                 ###" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ FROM --platform=linux/arm64 public.ecr.aws/lambda/python:3.13-arm64
 ARG TRUSTED_SSL_CERTS=./trusted_certs
 # Artifacts for kerberized sasl_ssl
 ARG SASL_SSL_ARTIFACTS=./sasl_ssl_artifacts
+RUN apk add --no-cache ca-certificates
 
 # Trusted certs
 COPY $TRUSTED_SSL_CERTS /opt/certs/
@@ -31,6 +32,7 @@ RUN \
   echo "######################################################" && \
   for FILE in `ls /opt/certs/*.pem /opt/certs/*.crt`; \
     do cat $FILE >> /etc/pki/tls/certs/ca-bundle.crt ; done && \
+      update-ca-certificates && \
   echo "###############################################" && \
   echo "### Install                                  ###" && \
   echo "### -> Basics                                 ###" && \


### PR DESCRIPTION
<!-- What problem does it solve or what feature does it add? -->
## Dockerfile fix to include .crt certificate extension.

<!-- Summarize the key changes for release notes. -->
## Release Notes
- Currently the docker image build fails with certificate issue as the for loop on the line 32 only imports the .pem files but we need to catch .crt newly added files as well.
- fix: `for FILE in `ls /opt/certs/*.pem /opt/certs/*.crf`; `

<!-- Add attached issue that this PR solves. -->
## Related
Closes #143 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced container certificate import to accept additional certificate formats.
  * Ensured external package downloads during build explicitly use the imported CA bundle for trusted TLS verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->