### PR TITLE
 Revert to form of original command, skip errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,10 @@ RUN \
   echo "######################################################" && \
   echo "### Import trusted certs before doing anything else ###" && \
   echo "######################################################" && \
-  for FILE in `ls /opt/certs/*.pem /opt/certs/*.crt 2>/dev/null`; \
-    do cat $FILE >> /etc/pki/tls/certs/ca-bundle.crt ; done && \
+    for FILE in `ls /opt/certs/*.pem /opt/certs/*.crt`; \
+      do [ -e "$FILE" ] || continue; \
+      cat "$FILE" >> /etc/pki/tls/certs/ca-bundle.crt; \
+      done && \
   echo "###############################################" && \
   echo "### Install                                  ###" && \
   echo "### -> Basics                                 ###" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,8 @@ RUN \
   echo "######################################################" && \
   echo "### Import trusted certs before doing anything else ###" && \
   echo "######################################################" && \
-    for FILE in `ls /opt/certs/*.pem /opt/certs/*.crt`; \
-      do [ -e "$FILE" ] || continue; \
-      cat "$FILE" >> /etc/pki/tls/certs/ca-bundle.crt; \
+    for CERT_PATH in "/opt/certs/"*.pem "/opt/certs/"*.crt; \
+      do [ -e "$CERT_PATH" ] && cat "$CERT_PATH" >> /etc/pki/tls/certs/ca-bundle.crt; \
       done && \
   echo "###############################################" && \
   echo "### Install                                  ###" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN \
   echo "######################################################" && \
   echo "### Import trusted certs before doing anything else ###" && \
   echo "######################################################" && \
-  find /opt/certs -type f \( -name "*.pem" -o -name "*.crt" \) -exec cat {} + >> /etc/pki/tls/certs/ca-bundle.crt && \
+  for FILE in `ls /opt/certs/*.pem /opt/certs/*.crt 2>/dev/null`; \
+    do cat $FILE >> /etc/pki/tls/certs/ca-bundle.crt ; done && \
   echo "###############################################" && \
   echo "### Install                                  ###" && \
   echo "### -> Basics                                 ###" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN \
   echo "### Import trusted certs before doing anything else ###" && \
   echo "######################################################" && \
     for CERT_PATH in "/opt/certs/"*.pem "/opt/certs/"*.crt; \
-      do [ -e "$CERT_PATH" ] && cat "$CERT_PATH" >> /etc/pki/tls/certs/ca-bundle.crt; \
+      do [ -e "$CERT_PATH" ] || continue; \
+        cat "$CERT_PATH" >> /etc/pki/tls/certs/ca-bundle.crt; \
       done && \
   echo "###############################################" && \
   echo "### Install                                  ###" && \


### PR DESCRIPTION
<!-- What problem does it solve or what feature does it add? -->
## Overview
The command `find` is not available in the base image.
Using `find` would be preferable to `ls`, but this is the best option in this case.
The PR reverts the cert enumeration command to the original and suppresses errors in the case that either `.pem` or `.crt` files are not found.

<!-- Summarize the key changes for release notes. -->
## Release Notes
- Revert to original cert enumeration command, suppress errors

<!-- Add attached issue that this PR solves. -->
## Related
Closes #181 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the container image build to more reliably import trusted TLS certificate files.
  * Updated how certificates are appended to the system CA bundle, ensuring only valid certificate matches are included during image creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->