### PR TITLE
fix: docker image had incorrect version of kafka lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,9 @@ RUN \
   echo "#################" && \
     mkdir -p /tmp/env-install-workdir/librdkafka && \
     cd /tmp/env-install-workdir/librdkafka && \
-    wget --ca-certificate=/etc/pki/tls/certs/ca-bundle.crt https://github.com/confluentinc/librdkafka/archive/v2.14.0.tar.gz && \
-    tar -xf v2.14.0.tar.gz && \
-    cd /tmp/env-install-workdir/librdkafka/librdkafka-2.14.0 && \
+    wget --ca-certificate=/etc/pki/tls/certs/ca-bundle.crt https://github.com/confluentinc/librdkafka/archive/v2.15.0.tar.gz && \
+    tar -xf v2.15.0.tar.gz && \
+    cd /tmp/env-install-workdir/librdkafka/librdkafka-2.15.0 && \
     ./configure && make && make install && \
   echo "###################" && \
   echo "### pip installs ###" && \


### PR DESCRIPTION
This pull request updates the version of `librdkafka` installed in the Docker build process. The change ensures the container uses the latest available release for improved features and security.

Dependency updates:

* Updated the `librdkafka` library from version 2.14.0 to 2.15.0 in the `Dockerfile` installation steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kafka client library used in builds to a newer release, which may improve compatibility and overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->